### PR TITLE
Remove the "board_id" parameter, since its confusing when there's

### DIFF
--- a/artdaq/Generators/CommandableFragmentGenerator.cc
+++ b/artdaq/Generators/CommandableFragmentGenerator.cc
@@ -58,12 +58,8 @@ artdaq::CommandableFragmentGenerator::CommandableFragmentGenerator(const fhicl::
     , exception_(false)
     , latest_exception_report_("none")
     , ev_counter_(1)
-    , board_id_(-1)
     , sleep_on_stop_us_(0)
 {
-	board_id_ = ps.get<int>("board_id");
-	instance_name_for_metrics_ = "BoardReader." + boost::lexical_cast<std::string>(board_id_);
-
 	auto fragment_ids = ps.get<std::vector<artdaq::Fragment::fragment_id_t>>("fragment_ids", std::vector<artdaq::Fragment::fragment_id_t>());
 
 	TLOG(TLVL_DEBUG + 33) << "artdaq::CommandableFragmentGenerator::CommandableFragmentGenerator(ps)";
@@ -89,10 +85,13 @@ artdaq::CommandableFragmentGenerator::CommandableFragmentGenerator(const fhicl::
 		throw cet::exception(latest_exception_report_);
 	}
 
+	int first_fragment_id = std::numeric_limits<int>::max();
 	for (auto& id : fragment_ids)
 	{
+		if (id < first_fragment_id) first_fragment_id = id;
 		expectedTypes_[id] = artdaq::Fragment::EmptyFragmentType;
 	}
+	instance_name_for_metrics_ = "BoardReader." + boost::lexical_cast<std::string>(first_fragment_id);
 
 	sleep_on_stop_us_ = ps.get<int>("sleep_on_stop_us", 0);
 }

--- a/artdaq/Generators/CommandableFragmentGenerator.hh
+++ b/artdaq/Generators/CommandableFragmentGenerator.hh
@@ -98,8 +98,6 @@ public:
 		fhicl::Atom<bool> separate_monitoring_thread{fhicl::Name{"separate_monitoring_thread"}, fhicl::Comment{"Whether a thread that calls the checkHWStatus_ method should be created"}, false};
 		/// "hardware_poll_interval_us" (Default: 0) : If a separate monitoring thread is used, how often should it call checkHWStatus_
 		fhicl::Atom<int64_t> hardware_poll_interval_us{fhicl::Name{"hardware_poll_interval_us"}, fhicl::Comment{"If a separate monitoring thread is used, how often should it call checkHWStatus_"}, 0};
-		/// "board_id" (REQUIRED) : The identification number for this CommandableFragmentGenerator
-		fhicl::Atom<int> board_id{fhicl::Name{"board_id"}, fhicl::Comment{"The identification number for this CommandableFragmentGenerator"}};
 		/// "fragment_ids" (Default: empty vector) : A list of Fragment IDs created by this CommandableFragmentGenerator
 		/// Note that only one of fragment_ids and fragment_id should be specified in the configuration
 		fhicl::Sequence<Fragment::fragment_id_t> fragment_ids{fhicl::Name("fragment_ids"), fhicl::Comment("A list of Fragment IDs created by this CommandableFragmentGenerator")};
@@ -337,12 +335,6 @@ protected:
 	bool check_stop();
 
 	/**
-	 * \brief Gets the current board_id
-	 * \return The current board_id
-	 */
-	int board_id() const { return board_id_; }
-
-	/**
 	 * \brief Increment the event counter
 	 * \param step Amount to increment the event counter by
 	 * \return The previous value of the event counter
@@ -423,7 +415,6 @@ private:
 	std::string latest_exception_report_;
 	std::atomic<size_t> ev_counter_;
 
-	int board_id_;
 	std::string instance_name_for_metrics_;
 
 	// Depending on what sleep_on_stop_us_ is set to, this gives the


### PR DESCRIPTION
already a "fragment_id" parameter. Use the lowest Fragment ID configured for the metric reporting name.