### PR TITLE
Add the ability to query the current shared memory manager ID from the

### DIFF
--- a/artdaq/ArtModules/ArtdaqGlobalsService.h
+++ b/artdaq/ArtModules/ArtdaqGlobalsService.h
@@ -61,6 +61,12 @@ public:
 	 */
 	std::shared_ptr<artdaq::detail::RawEventHeader> GetEventHeader() override { return nullptr; }
 
+	/**
+	 * \brief Get the ID of this art process. Always 0 since ArtdaqGlobalsService does not connect to shared memory
+	 * \return 0
+	*/
+	size_t GetMyId() override { return 0; }
+
 private:
 	ArtdaqGlobalsService(ArtdaqGlobalsService const&) = delete;
 	ArtdaqGlobalsService(ArtdaqGlobalsService&&) = delete;

--- a/artdaq/ArtModules/ArtdaqGlobalsService_service.cc
+++ b/artdaq/ArtModules/ArtdaqGlobalsService_service.cc
@@ -18,26 +18,25 @@ ArtdaqGlobalsService::ArtdaqGlobalsService(fhicl::ParameterSet const& pset, art:
 	TLOG(TLVL_DEBUG + 33) << "ArtdaqGlobalsService CONSTRUCTOR";
 
 	char const* artapp_env = getenv("ARTDAQ_APPLICATION_NAME");
-	std::string artapp_str;
+	std::string artapp_str = "art";
 	if (artapp_env != nullptr)
 	{
-		artapp_str = std::string(artapp_env) + "_";
+		artapp_str = std::string(artapp_env) + "_art";
 	}
 
-	TLOG(TLVL_DEBUG + 33) << "Setting app_name";
+	TLOG(TLVL_DEBUG + 33) << "Setting app_name to " << artapp_str;
+		app_name = artapp_str;
 
 	artapp_env = getenv("ARTDAQ_RANK");
 	if (artapp_env != nullptr && my_rank < 0)
 	{
 		TLOG(TLVL_DEBUG + 33) << "Setting rank from envrionment";
 		my_rank = strtol(artapp_env, nullptr, 10);
-		app_name = artapp_str + "art" + std::string(artapp_env);
 	}
 	else
 	{
-		TLOG(TLVL_DEBUG + 33) << "Setting default rank and name";
+		TLOG(TLVL_DEBUG + 33) << "Setting default rank";
 		my_rank = -1;
-		app_name = artapp_str + "art";
 	}
 
 	try

--- a/artdaq/ArtModules/ArtdaqSharedMemoryServiceInterface.h
+++ b/artdaq/ArtModules/ArtdaqSharedMemoryServiceInterface.h
@@ -43,6 +43,12 @@ public:
 	 */
 	virtual std::shared_ptr<artdaq::detail::RawEventHeader> GetEventHeader() = 0;
 
+	/**
+	 * \brief Get the ID of this art process
+	 * \return The ID of this art process (from shm->GetMyId())
+	*/
+	virtual size_t GetMyId() = 0;
+
 private:
 	ArtdaqSharedMemoryServiceInterface(ArtdaqSharedMemoryServiceInterface const&) = delete;
 	ArtdaqSharedMemoryServiceInterface(ArtdaqSharedMemoryServiceInterface&&) = delete;

--- a/artdaq/ArtModules/ArtdaqSharedMemoryService_service.cc
+++ b/artdaq/ArtModules/ArtdaqSharedMemoryService_service.cc
@@ -76,6 +76,12 @@ public:
 	 */
 	std::shared_ptr<artdaq::detail::RawEventHeader> GetEventHeader() override { return evtHeader_; }
 
+	/**
+	 * \brief Get the ID of this art process
+	 * \return The ID of this art process from the shared memory segment
+	*/
+	size_t GetMyId() override { return incoming_events_->GetMyId(); }
+
 private:
 	ArtdaqSharedMemoryService(ArtdaqSharedMemoryService const&) = delete;
 	ArtdaqSharedMemoryService(ArtdaqSharedMemoryService&&) = delete;

--- a/artdaq/ArtModules/CMakeLists.txt
+++ b/artdaq/ArtModules/CMakeLists.txt
@@ -238,6 +238,10 @@ cet_build_plugin(TransferOutput art::module
   TRACE::MF
 )
 
+cet_build_plugin(OffsetPrescale art::EDFilter
+  LIBRARIES PRIVATE
+  artdaq_plugin_types::ArtdaqSharedMemoryService
+)
 
 include(mfPlugin)
 mfPlugin( ArtdaqMetric LIBRARIES REG artdaq::DAQdata )

--- a/artdaq/ArtModules/OffsetPrescale_module.cc
+++ b/artdaq/ArtModules/OffsetPrescale_module.cc
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       OffsetPrescale
+// Plugin Type: filter (Unknown Unknown)
+// File:        OffsetPrescale_module.cc
+//
+// Generated at Mon Sep 11 12:28:36 2023 by Eric Flumerfelt using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "artdaq/ArtModules/ArtdaqSharedMemoryServiceInterface.h"
+
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include <memory>
+
+namespace artdaq {
+  class OffsetPrescale;
+}
+
+
+class artdaq::OffsetPrescale : public art::EDFilter {
+public:
+  explicit OffsetPrescale(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  OffsetPrescale(OffsetPrescale const&) = delete;
+  OffsetPrescale(OffsetPrescale&&) = delete;
+  OffsetPrescale& operator=(OffsetPrescale const&) = delete;
+  OffsetPrescale& operator=(OffsetPrescale&&) = delete;
+
+  // Required functions.
+  bool filter(art::Event& e) override;
+
+private:
+
+  // Declare member data here.
+	size_t events_skip_;
+	size_t offset_{0};
+
+};
+
+
+artdaq::OffsetPrescale::OffsetPrescale(fhicl::ParameterSet const& p)
+  : EDFilter{p} 
+	, events_skip_(p.get<size_t>("prescale", 1))
+{
+	art::ServiceHandle<ArtdaqSharedMemoryServiceInterface> shm;
+	offset_ = shm->GetMyId();
+}
+
+bool artdaq::OffsetPrescale::filter(art::Event& e)
+{
+	auto eid = e.event();
+	return eid >= offset_ 
+		&& (eid - offset_) % events_skip_ == 0;
+}
+
+DEFINE_ART_MODULE(artdaq::OffsetPrescale)


### PR DESCRIPTION
ArtdaqSharedMemoryServiceInterface. Improve handling of app name in ArtdaqGlobalsService where this ID is not available. Add simple prescaler module which demonstrates using this ID to offset.