### PR TITLE
Ignore more Spack build artifacts. Add INSTALL_BIN to cet_test calls …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj/*
 *.vcxproj*
 core.*
 spack-build-*
+build-linux-*

--- a/test/ArtModules/CMakeLists.txt
+++ b/test/ArtModules/CMakeLists.txt
@@ -9,7 +9,7 @@ cet_build_plugin(FragmentSniffer art::EDAnalyzer
 #    message(STATUS "${_variableName}=${${_variableName}}")
 #endforeach()
 
-cet_test(daq_flow_t
+cet_test(daq_flow_t INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq::ArtConfig
   artdaq::Application
@@ -23,7 +23,7 @@ cet_test(daq_flow_t
   DATAFILES daq_flow_t.fcl
 )
 
-cet_test(reconfigure_t
+cet_test(reconfigure_t INSTALL_BIN
   LIBRARIES
   artdaq::ArtConfig
   artdaq::Application

--- a/test/DAQdata/CMakeLists.txt
+++ b/test/DAQdata/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cet_test(GenericFragmentSimulator_t USE_BOOST_UNIT
+cet_test(GenericFragmentSimulator_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_core::artdaq-core_Plugins
   artdaq_core::artdaq-core_Data

--- a/test/DAQrate/CMakeLists.txt
+++ b/test/DAQrate/CMakeLists.txt
@@ -22,20 +22,20 @@ cet_test(FragCounter_t USE_BOOST_UNIT
 
 # DataSenderManager is tested as part of the TransferTest
 
-cet_test(DataReceiverManager_t USE_BOOST_UNIT
+cet_test(DataReceiverManager_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq::DAQrate
   artdaq::TransferPlugins
   artdaq::TransferPlugins_Shmem_transfer
 )
 
-cet_test(RequestSender_t USE_BOOST_UNIT
+cet_test(RequestSender_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq::DAQrate
   artdaq_core::artdaq-core_Utilities
 )
 
-cet_test(SharedMemoryEventManager_t USE_BOOST_UNIT
+cet_test(SharedMemoryEventManager_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq::DAQrate
   Threads::Threads
@@ -48,7 +48,7 @@ cet_test(requestsender HANDBUILT
   DATAFILES requestsender.fcl
 )
 
-cet_test(FragmentBuffer_t USE_BOOST_UNIT
+cet_test(FragmentBuffer_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq::DAQrate
   artdaq_core::artdaq-core_Data

--- a/test/Generators/CMakeLists.txt
+++ b/test/Generators/CMakeLists.txt
@@ -1,4 +1,4 @@
-cet_test(CommandableFragmentGenerator_t USE_BOOST_UNIT
+cet_test(CommandableFragmentGenerator_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_plugin_types::CommandableFragmentGenerator
   artdaq::DAQdata

--- a/test/RoutingPolicies/CMakeLists.txt
+++ b/test/RoutingPolicies/CMakeLists.txt
@@ -1,20 +1,12 @@
 
-cet_test(RoundRobin_policy_t USE_BOOST_UNIT
+cet_test(RoundRobin_policy_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_plugin_support::policyMaker
   artdaq_plugin_types::policy
   fhiclcpp::fhiclcpp
 )
 
-cet_test(NoOp_policy_t USE_BOOST_UNIT
-  LIBRARIES PRIVATE
-  artdaq_plugin_support::policyMaker
-  artdaq_plugin_types::policy
-  fhiclcpp::fhiclcpp
-  TRACE::MF
-)
-
-cet_test(CapacityTest_policy_t USE_BOOST_UNIT
+cet_test(NoOp_policy_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_plugin_support::policyMaker
   artdaq_plugin_types::policy
@@ -22,7 +14,15 @@ cet_test(CapacityTest_policy_t USE_BOOST_UNIT
   TRACE::MF
 )
 
-cet_test(PreferSameHost_policy_t USE_BOOST_UNIT
+cet_test(CapacityTest_policy_t USE_BOOST_UNIT INSTALL_BIN
+  LIBRARIES PRIVATE
+  artdaq_plugin_support::policyMaker
+  artdaq_plugin_types::policy
+  fhiclcpp::fhiclcpp
+  TRACE::MF
+)
+
+cet_test(PreferSameHost_policy_t USE_BOOST_UNIT INSTALL_BIN
   LIBRARIES PRIVATE
   artdaq_plugin_support::policyMaker
   artdaq_plugin_types::policy


### PR DESCRIPTION
…so that the unit tests can be run from installed products