### PR TITLE
Introduce more strict controls over the order in which events are presented to art.

### DIFF
--- a/artdaq/ArtModules/ArtdaqEvent.hh
+++ b/artdaq/ArtModules/ArtdaqEvent.hh
@@ -1,0 +1,101 @@
+#ifndef artdaq_ArtModules_ArtdaqEvent_hh
+#define artdaq_ArtModules_ArtdaqEvent_hh
+
+#include "artdaq-core/Data/RawEvent.hh"
+
+/**
+ * \brief An Artdaq Event, consisting of a header and a map of contained Fragments
+ */
+struct ArtdaqEvent
+{
+	std::shared_ptr<artdaq::detail::RawEventHeader> header;
+	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> fragments;
+
+	ArtdaqEvent()
+	    : header(nullptr), fragments() {}
+
+	artdaq::Fragment::type_t FirstFragmentType() const
+	{
+		if (fragments.empty()) return artdaq::Fragment::InvalidFragmentType;
+		return fragments.begin()->first;
+	}
+};
+
+inline bool operator<(ArtdaqEvent const& l, ArtdaqEvent const& r)
+{
+	auto left = l.FirstFragmentType();
+	auto right = r.FirstFragmentType();
+	// Init Fragments are always first, EndOfData Fragments are always last
+	if (left == artdaq::Fragment::InitFragmentType || right == artdaq::Fragment::InitFragmentType 
+        || left == artdaq::Fragment::EndOfDataFragmentType || right == artdaq::Fragment::EndOfDataFragmentType)
+	{
+		if (left == right)
+		{
+			// Stable ordering
+			return l.header->sequence_id < r.header->sequence_id;
+		}
+		else
+		{
+			return left == artdaq::Fragment::InitFragmentType || right == artdaq::Fragment::EndOfDataFragmentType;
+		}
+	}
+	else if (l.header->run_id == r.header->run_id)
+	{
+		// StartRun are first within a run, EndRun are last
+		if (left == artdaq::Fragment::StartOfRunFragmentType || right == artdaq::Fragment::StartOfRunFragmentType 
+            || left == artdaq::Fragment::EndOfRunFragmentType || right == artdaq::Fragment::EndOfRunFragmentType 
+            || left == artdaq::Fragment::RunDataFragmentType || right == artdaq::Fragment::RunDataFragmentType)
+		{
+			if (left == right)
+			{
+				// Stable ordering
+				return l.header->sequence_id < r.header->sequence_id;
+			}
+			else
+			{
+				return left == artdaq::Fragment::StartOfRunFragmentType || right == artdaq::Fragment::EndOfRunFragmentType || right == artdaq::Fragment::RunDataFragmentType;
+			}
+		}
+
+		if (l.header->subrun_id == r.header->subrun_id)
+		{
+			// StartSubrun are first within a subrun, EndSubrun are last
+			if (left == artdaq::Fragment::StartOfSubrunFragmentType || right == artdaq::Fragment::StartOfSubrunFragmentType 
+                || left == artdaq::Fragment::EndOfSubrunFragmentType || right == artdaq::Fragment::EndOfSubrunFragmentType 
+                || left == artdaq::Fragment::SubrunDataFragmentType || right == artdaq::Fragment::SubrunDataFragmentType)
+			{
+				if (left == right)
+				{
+					// Stable ordering
+					return l.header->sequence_id < r.header->sequence_id;
+				}
+				else
+				{
+					return left == artdaq::Fragment::StartOfSubrunFragmentType || right == artdaq::Fragment::EndOfSubrunFragmentType || right == artdaq::Fragment::SubrunDataFragmentType;
+				}
+			}
+
+			// Order by sequence ID if not a recognized system broadcast
+			return l.header->sequence_id < r.header->sequence_id;
+		}
+		else
+		{
+			return l.header->subrun_id < r.header->subrun_id;
+		}
+	}
+	else
+	{
+		return l.header->run_id < r.header->run_id;
+	}
+}
+
+inline bool operator<(std::shared_ptr<ArtdaqEvent> const& l, std::shared_ptr<ArtdaqEvent> const& r)
+{
+	return *l < *r;
+}
+
+#endif /* artdaq_ArtModules_ArtdaqEvent_hh */
+
+// Local Variables:
+// mode: c++
+// End:

--- a/artdaq/ArtModules/ArtdaqGlobalsService.h
+++ b/artdaq/ArtModules/ArtdaqGlobalsService.h
@@ -40,9 +40,9 @@ public:
 	 * \brief Pretend to receive an event from the shared memory
 	 * \return Map of Fragment types retrieved from shared memory
 	 */
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> ReceiveEvent(bool) override
+	std::shared_ptr<ArtdaqEvent> ReceiveEvent(bool) override
 	{
-		return std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>>();
+		return nullptr;
 	}
 
 	/**
@@ -50,16 +50,12 @@ public:
 	 * \return The number of events which can be read (0)
 	 */
 	size_t GetQueueSize() override { return 0; }
-	/**
+
+    /**
 	 * \brief Get the maximum number of events which can be stored in the shared memory (0)
 	 * \return The maximum number of events which can be stored in the shared memory (0)
 	 */
 	size_t GetQueueCapacity() override { return 0; }
-	/**
-	 * \brief Get a shared_ptr to the current event header, if any
-	 * \return Nullptr
-	 */
-	std::shared_ptr<artdaq::detail::RawEventHeader> GetEventHeader() override { return nullptr; }
 
 	/**
 	 * \brief Get the ID of this art process. Always 0 since ArtdaqGlobalsService does not connect to shared memory

--- a/artdaq/ArtModules/ArtdaqInputHelper.hh
+++ b/artdaq/ArtModules/ArtdaqInputHelper.hh
@@ -149,7 +149,7 @@ private:
 	                               art::SubRunPrincipal* const, art::RunPrincipal*&, art::SubRunPrincipal*&,
 	                               art::EventPrincipal*&);
 
-	bool constructPrincipal(artdaq::Fragment::type_t, art::RunPrincipal* const,
+	bool constructPrincipal(std::shared_ptr<ArtdaqEvent>, art::RunPrincipal* const,
 	                        art::SubRunPrincipal* const, art::RunPrincipal*&, art::SubRunPrincipal*&,
 	                        art::EventPrincipal*&);
 
@@ -536,7 +536,7 @@ void art::ArtdaqInputHelper<U>::readAndConstructPrincipal(std::unique_ptr<TBuffe
 		                                           << subrun_aux->subRun();
 
 		art::SubRunID subrun_check(subrun_aux->run(), subrun_aux->subRun());
-		if (inSR == nullptr || subrun_check != inSR->subRunID())
+		if (inSR == nullptr || !inSR->subRunID().isValid() || subrun_check != inSR->subRunID())
 		{
 			// New SubRun, either we have no input SubRunPrincipal, or the
 			// input subRun number does not match the subRun number.
@@ -589,7 +589,8 @@ void art::ArtdaqInputHelper<U>::readAndConstructPrincipal(std::unique_ptr<TBuffe
 	{
 		TLOG(TLVL_DEBUG + 39, "ArtdaqInputHelper") << "No principals created, making Flush Event based on whether there was an existing SubRun";
 
-		if (!inSR || !inSR->subRunID().isValid()) {
+		if (!inSR || !inSR->subRunID().isValid())
+		{
 			TLOG(TLVL_DEBUG + 39, "ArtdaqInputHelper") << "readAndConstructPrincipal: Making run flush event";
 			art::EventID const flush_evid(art::EventID::flushEvent(inR->runID()));
 			outSR = pm_.makeSubRunPrincipal(flush_evid.subRunID(), currentTime);
@@ -605,22 +606,21 @@ void art::ArtdaqInputHelper<U>::readAndConstructPrincipal(std::unique_ptr<TBuffe
 }
 
 template<typename U>
-bool art::ArtdaqInputHelper<U>::constructPrincipal(artdaq::Fragment::type_t firstFragmentType, art::RunPrincipal* const inR, art::SubRunPrincipal* const inSR, art::RunPrincipal*& outR, art::SubRunPrincipal*& outSR, art::EventPrincipal*& outE)
+bool art::ArtdaqInputHelper<U>::constructPrincipal(std::shared_ptr<ArtdaqEvent> eventPtr, art::RunPrincipal* const inR, art::SubRunPrincipal* const inSR, art::RunPrincipal*& outR, art::SubRunPrincipal*& outSR, art::EventPrincipal*& outE)
 {
 	// We return false, indicating we're done reading, if:
 	//   1) we did not obtain an event, because we timed out and were
 	//      configured NOT to keep trying after a timeout, or
 	//   2) the event we read was the end-of-data marker: a null
 	//      pointer
-	if (firstFragmentType == artdaq::Fragment::EndOfDataFragmentType)
+	if (eventPtr->FirstFragmentType() == artdaq::Fragment::EndOfDataFragmentType)
 	{
 		TLOG(TLVL_DEBUG + 32, "ArtdaqInputHelper") << "Received shutdown message, returning false";
 		shutdownMsgReceived_ = true;
 		return false;
 	}
 
-	auto evtHeader = communicationWrapper_.getEventHeader();
-	if (!evtHeader)
+	if (!eventPtr->header)
 	{
 		TLOG_ERROR("ArtdaqInputHelper") << "No RawEventHeader received, cannot construct principals!";
 		shutdownMsgReceived_ = true;
@@ -631,11 +631,6 @@ bool art::ArtdaqInputHelper<U>::constructPrincipal(artdaq::Fragment::type_t firs
 	// fragment and that fragment is marked as EndRun or EndSubrun we'll create
 	// the special principals for that.
 	art::Timestamp currentTime = 0;
-#if 0
-				art::TimeValue_t lo_res_time = time(0);
-				TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "lo_res_time = " << lo_res_time;
-				currentTime = ((lo_res_time & 0xffffffff) << 32);
-#endif
 	timespec hi_res_time;
 	int retcode = clock_gettime(CLOCK_REALTIME, &hi_res_time);
 	TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "hi_res_time tv_sec = " << hi_res_time.tv_sec
@@ -648,25 +643,10 @@ bool art::ArtdaqInputHelper<U>::constructPrincipal(artdaq::Fragment::type_t firs
 	{
 		TLOG_ERROR("ArtdaqInputHelper")
 		    << "Unable to fetch a high-resolution time with clock_gettime for art::Event Timestamp. "
-		    << "The art::Event Timestamp will be zero for event " << evtHeader->event_id;
+		    << "The art::Event Timestamp will be zero for event " << eventPtr->header->event_id;
 	}
 
-	// make new run if inR is 0 or if the run has changed
-	if (inR == nullptr || inR->run() != evtHeader->run_id)
-	{
-		TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making run principal with run_id " << evtHeader->run_id;
-		outR = pm_.makeRunPrincipal(evtHeader->run_id, currentTime);
-	}
-
-	// make new subrun if inSR is 0 or if the subrun has changed
-	art::SubRunID subrun_check(evtHeader->run_id, evtHeader->subrun_id);
-	if (inSR == nullptr || subrun_check != inSR->subRunID())
-	{
-		TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making subrun principal with subrun_id " << evtHeader->subrun_id;
-		outSR = pm_.makeSubRunPrincipal(evtHeader->run_id, evtHeader->subrun_id, currentTime);
-	}
-
-	if (firstFragmentType == artdaq::Fragment::EndOfRunFragmentType)
+	if (eventPtr->FirstFragmentType() == artdaq::Fragment::EndOfRunFragmentType)
 	{
 		TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "EndOfRunFragment received, returning Flush event";
 		art::EventID const evid(art::EventID::flushEvent());
@@ -675,14 +655,16 @@ bool art::ArtdaqInputHelper<U>::constructPrincipal(artdaq::Fragment::type_t firs
 		outE = pm_.makeEventPrincipal(evid, currentTime);
 		return true;
 	}
-	else if (firstFragmentType == artdaq::Fragment::EndOfSubrunFragmentType)
+
+	if (eventPtr->FirstFragmentType() == artdaq::Fragment::EndOfSubrunFragmentType)
 	{
 		TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "EndOfSubrunFragment received, creating new Subrun Principal";
 		// Check if inR == 0 or is a new run
-		if (inR == nullptr || inR->run() != evtHeader->run_id)
+		if (inR == nullptr || !inR->runID().isValid() || inR->run() != eventPtr->header->run_id)
 		{
-			TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making subrun principal with subrun_id " << evtHeader->subrun_id;
-			outSR = pm_.makeSubRunPrincipal(evtHeader->run_id, evtHeader->subrun_id, currentTime);
+			TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making subrun principal with subrun_id " << eventPtr->header->subrun_id;
+			if (outSR) delete outSR;
+			outSR = pm_.makeSubRunPrincipal(eventPtr->header->run_id, eventPtr->header->subrun_id, currentTime);
 			art::EventID const evid(art::EventID::flushEvent(outSR->subRunID()));
 			outE = pm_.makeEventPrincipal(evid, currentTime);
 		}
@@ -692,7 +674,7 @@ bool art::ArtdaqInputHelper<U>::constructPrincipal(artdaq::Fragment::type_t firs
 			// subrun, then it must have been associated with a data event.  In that case, we need
 			// to generate a flush event with a valid run but flush subrun and event number in order
 			// to end the subrun.
-			if (inSR != nullptr && !inSR->subRunID().isFlush() && inSR->subRun() == evtHeader->subrun_id)
+			if (inSR != nullptr && !inSR->subRunID().isFlush() && inSR->subRun() == eventPtr->header->subrun_id)
 			{
 				TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Flushing old run id " << inR->runID();
 				art::EventID const evid(art::EventID::flushEvent(inR->runID()));
@@ -704,20 +686,34 @@ bool art::ArtdaqInputHelper<U>::constructPrincipal(artdaq::Fragment::type_t firs
 			}
 			else
 			{
-				TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making subrun principal with subrun_id " << evtHeader->subrun_id;
-				outSR = pm_.makeSubRunPrincipal(evtHeader->run_id, evtHeader->subrun_id, currentTime);
+				TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making subrun principal with subrun_id " << eventPtr->header->subrun_id;
+				outSR = pm_.makeSubRunPrincipal(eventPtr->header->run_id, eventPtr->header->subrun_id, currentTime);
 				art::EventID const evid(art::EventID::flushEvent(outSR->subRunID()));
 				outE = pm_.makeEventPrincipal(evid, currentTime);
 				// Possible error condition
 				//} else {
 			}
-			outR = nullptr;
 		}
 		return true;
 	}
 
-	TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making event principal with event_id " << evtHeader->event_id;
-	outE = pm_.makeEventPrincipal(evtHeader->run_id, evtHeader->subrun_id, evtHeader->event_id, currentTime);
+	// make new run if inR is 0 or if the run has changed
+	if (inR == nullptr || !inR->runID().isValid() || inR->run() != eventPtr->header->run_id)
+	{
+		TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making run principal with run_id " << eventPtr->header->run_id;
+		outR = pm_.makeRunPrincipal(eventPtr->header->run_id, currentTime);
+	}
+
+	// make new subrun if inSR is 0 or if the subrun has changed
+	art::SubRunID subrun_check(eventPtr->header->run_id, eventPtr->header->subrun_id);
+	if (inSR == nullptr || !inSR->subRunID().isValid() || subrun_check != inSR->subRunID())
+	{
+		TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making subrun principal with subrun_id " << eventPtr->header->subrun_id;
+		outSR = pm_.makeSubRunPrincipal(eventPtr->header->run_id, eventPtr->header->subrun_id, currentTime);
+	}
+
+	TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "Making event principal with event_id " << eventPtr->header->event_id;
+	outE = pm_.makeEventPrincipal(eventPtr->header->run_id, eventPtr->header->subrun_id, eventPtr->header->event_id, currentTime);
 	return true;
 }
 
@@ -976,10 +972,10 @@ bool art::ArtdaqInputHelper<U>::readNext(art::RunPrincipal* const inR, art::SubR
 
 	auto read_start_time = std::chrono::steady_clock::now();
 
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> eventMap = communicationWrapper_.receiveMessages();
+	std::shared_ptr<ArtdaqEvent> eventMap = communicationWrapper_.receiveMessages();
 	auto got_event_time = std::chrono::steady_clock::now();
 
-	if (eventMap.empty())
+	if (eventMap == nullptr)
 	{
 		TLOG(TLVL_ERROR, "ArtdaqInputHelper") << "No Fragments received! Aborting...";
 		shutdownMsgReceived_ = true;
@@ -987,7 +983,7 @@ bool art::ArtdaqInputHelper<U>::readNext(art::RunPrincipal* const inR, art::SubR
 		return false;
 	}
 
-	if (eventMap.count(artdaq::Fragment::EndOfDataFragmentType))
+	if (eventMap->FirstFragmentType() == artdaq::Fragment::EndOfDataFragmentType)
 	{
 		TLOG(TLVL_ERROR, "ArtdaqInputHelper") << "Shutdown message received!";
 		shutdownMsgReceived_ = true;
@@ -997,16 +993,16 @@ bool art::ArtdaqInputHelper<U>::readNext(art::RunPrincipal* const inR, art::SubR
 
 	if (fragmentsOnlyMode_)
 	{
-		if (eventMap.count(artdaq::Fragment::DataFragmentType) || eventMap.count(artdaq::Fragment::RunDataFragmentType) || eventMap.count(artdaq::Fragment::SubrunDataFragmentType))
+		if (eventMap->fragments.count(artdaq::Fragment::DataFragmentType) || eventMap->fragments.count(artdaq::Fragment::RunDataFragmentType) || eventMap->fragments.count(artdaq::Fragment::SubrunDataFragmentType))
 		{
 			TLOG(TLVL_DEBUG + 43, "ArtdaqInputHelper") << "ArtdaqInputHelper::readNext unexpectedly got a message with a DataFragment. This art Event will NOT be reconstructed!";
 		}
 
-		auto firstFragmentType = eventMap.begin()->first;
+		auto firstFragmentType = eventMap->FirstFragmentType();
 		TLOG(TLVL_DEBUG + 32, "ArtdaqInputHelper") << "First Fragment type is " << static_cast<int>(firstFragmentType);
-		if (constructPrincipal(firstFragmentType, inR, inSR, outR, outSR, outE))
+		if (constructPrincipal(eventMap, inR, inSR, outR, outSR, outE))
 		{
-			auto rfret = readFragments(eventMap, outR ? outR : inR, outSR ? outSR : inSR, outE);
+			auto rfret = readFragments(eventMap->fragments, outR ? outR : inR, outSR ? outSR : inSR, outE);
 
 			// No event data
 			if (!rfret.second)
@@ -1028,33 +1024,27 @@ bool art::ArtdaqInputHelper<U>::readNext(art::RunPrincipal* const inR, art::SubR
 					}
 				}
 			}
-
-			// Nasty hack here. Don't return a new Run/Subrun Principal without an associated Event Principal
-			if (outE == nullptr && ((outR != nullptr && !outR->runID().isFlush()) || (outSR != nullptr && !outSR->subRunID().isFlush())))
-			{
-				return readNext(outR ? outR : inR, outSR ? outSR : inSR, outR, outSR, outE);
-			}
 		}
 	}
 	else
 	{
 		std::list<std::unique_ptr<TBufferFile>> msgs;
-		if (eventMap.count(artdaq::Fragment::DataFragmentType))
-			for (auto& dataFrag : *(eventMap[artdaq::Fragment::DataFragmentType]))
+		if (eventMap->fragments.count(artdaq::Fragment::RunDataFragmentType))
+			for (auto& dataFrag : *(eventMap->fragments[artdaq::Fragment::RunDataFragmentType]))
 			{
 				if (!dataFrag.hasMetadata()) continue;
 				auto header = dataFrag.metadata<artdaq::NetMonHeader>();
 				msgs.emplace_back(new TBufferFile(TBuffer::kRead, header->data_length, dataFrag.dataBegin(), kFALSE, nullptr));
 			}
-		if (eventMap.count(artdaq::Fragment::RunDataFragmentType))
-			for (auto& dataFrag : *(eventMap[artdaq::Fragment::RunDataFragmentType]))
+		if (eventMap->fragments.count(artdaq::Fragment::SubrunDataFragmentType))
+			for (auto& dataFrag : *(eventMap->fragments[artdaq::Fragment::SubrunDataFragmentType]))
 			{
 				if (!dataFrag.hasMetadata()) continue;
 				auto header = dataFrag.metadata<artdaq::NetMonHeader>();
 				msgs.emplace_back(new TBufferFile(TBuffer::kRead, header->data_length, dataFrag.dataBegin(), kFALSE, nullptr));
 			}
-		if (eventMap.count(artdaq::Fragment::SubrunDataFragmentType))
-			for (auto& dataFrag : *(eventMap[artdaq::Fragment::SubrunDataFragmentType]))
+		if (eventMap->fragments.count(artdaq::Fragment::DataFragmentType))
+			for (auto& dataFrag : *(eventMap->fragments[artdaq::Fragment::DataFragmentType]))
 			{
 				if (!dataFrag.hasMetadata()) continue;
 				auto header = dataFrag.metadata<artdaq::NetMonHeader>();
@@ -1128,9 +1118,9 @@ bool art::ArtdaqInputHelper<U>::readNext(art::RunPrincipal* const inR, art::SubR
 			// Event message.
 			readDataProducts(msgs, outE);
 
-			if (eventMap.size() > 1)
+			if (eventMap->fragments.size() > 1)
 			{
-				readFragments(eventMap, outR ? outR : inR, outSR ? outSR : inSR, outE);
+				readFragments(eventMap->fragments, outR ? outR : inR, outSR ? outSR : inSR, outE);
 			}
 
 			TLOG(TLVL_DEBUG + 47, "ArtdaqInputHelper") << "readNext: returning true on Event message.";
@@ -1145,7 +1135,7 @@ bool art::ArtdaqInputHelper<U>::readNext(art::RunPrincipal* const inR, art::SubR
 	if (outE != nullptr)
 	{
 		auto artHdrPtr = std::make_unique<artdaq::detail::RawEventHeader>();
-		auto daqHdrPtr = communicationWrapper_.getEventHeader();
+		auto daqHdrPtr = eventMap->header;
 
 		if (daqHdrPtr != nullptr)
 		{

--- a/artdaq/ArtModules/ArtdaqSharedMemoryServiceInterface.h
+++ b/artdaq/ArtModules/ArtdaqSharedMemoryServiceInterface.h
@@ -3,6 +3,7 @@
 
 #include "art/Framework/Services/Registry/ServiceMacros.h"
 #include "artdaq-core/Data/RawEvent.hh"
+#include "artdaq/ArtModules/ArtdaqEvent.hh"
 #include "fhiclcpp/types/Atom.h"
 
 /**
@@ -11,6 +12,7 @@
 class ArtdaqSharedMemoryServiceInterface
 {
 public:
+
 	ArtdaqSharedMemoryServiceInterface() = default;
 
 	/**
@@ -21,9 +23,9 @@ public:
 	/**
 	 * \brief Receive an event from the shared memory
 	 * \param broadcast Whether to only attempt to receive a broadcast (broadcasts are always preferentially received over data)
-	 * \return Map of Fragment types retrieved from shared memory
+	 * \return Event Struct received from shared memory
 	 */
-	virtual std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> ReceiveEvent(bool broadcast) = 0;
+	virtual std::shared_ptr<ArtdaqEvent> ReceiveEvent(bool broadcast) = 0;
 
 	/**
 	 * \brief Get the number of events which are ready to be read
@@ -38,15 +40,9 @@ public:
 	virtual size_t GetQueueCapacity() = 0;
 
 	/**
-	 * \brief Get a shared_ptr to the current event header, if any
-	 * \return std::shared_ptr to current event header. May be nullptr if no event is currently being read
-	 */
-	virtual std::shared_ptr<artdaq::detail::RawEventHeader> GetEventHeader() = 0;
-
-	/**
 	 * \brief Get the ID of this art process
 	 * \return The ID of this art process (from shm->GetMyId())
-	*/
+	 */
 	virtual size_t GetMyId() = 0;
 
 private:

--- a/artdaq/ArtModules/ArtdaqSharedMemoryService_service.cc
+++ b/artdaq/ArtModules/ArtdaqSharedMemoryService_service.cc
@@ -54,32 +54,28 @@ public:
 	ArtdaqSharedMemoryService(fhicl::ParameterSet const& pset, art::ActivityRegistry&);
 
 	/**
-	 * \brief Receive an event from the shared memory
+	 * \brief Receive event(s) from the shared memory
 	 * \param broadcast Whether to only attempt to receive a broadcast (broadcasts are always preferentially received over data)
 	 * \return Map of Fragment types retrieved from shared memory
 	 */
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> ReceiveEvent(bool broadcast) override;
+	std::shared_ptr<ArtdaqEvent> ReceiveEvent(bool broadcast) override;
 
 	/**
 	 * \brief Get the number of events which are ready to be read
 	 * \return The number of events which can be read
 	 */
 	size_t GetQueueSize() override { return incoming_events_->ReadReadyCount(); }
+
 	/**
 	 * \brief Get the maximum number of events which can be stored in the shared memory
 	 * \return The maximum number of events which can be stored in the shared memory
 	 */
 	size_t GetQueueCapacity() override { return incoming_events_->size(); }
-	/**
-	 * \brief Get a shared_ptr to the current event header, if any
-	 * \return std::shared_ptr to current event header. May be nullptr if no event is currently being read
-	 */
-	std::shared_ptr<artdaq::detail::RawEventHeader> GetEventHeader() override { return evtHeader_; }
 
 	/**
 	 * \brief Get the ID of this art process
 	 * \return The ID of this art process from the shared memory segment
-	*/
+	 */
 	size_t GetMyId() override { return incoming_events_->GetMyId(); }
 
 private:
@@ -88,10 +84,13 @@ private:
 	ArtdaqSharedMemoryService& operator=(ArtdaqSharedMemoryService const&) = delete;
 	ArtdaqSharedMemoryService& operator=(ArtdaqSharedMemoryService&&) = delete;
 
+	std::shared_ptr<ArtdaqEvent> ReadEventFromSharedMemory(bool broadcast);
+
 private:
 	std::unique_ptr<artdaq::SharedMemoryEventReceiver> incoming_events_;
-	std::shared_ptr<artdaq::detail::RawEventHeader> evtHeader_;
+	std::list<std::shared_ptr<ArtdaqEvent>> event_ordering_;
 	size_t read_timeout_;
+	bool last_read_timeout_{false};
 	bool resume_after_timeout_;
 	bool printed_exit_message_{false};
 };
@@ -104,7 +103,7 @@ static fhicl::ParameterSet empty_pset;
 
 ArtdaqSharedMemoryService::ArtdaqSharedMemoryService(fhicl::ParameterSet const& pset, art::ActivityRegistry& /*unused*/)
     : incoming_events_(nullptr)
-    , evtHeader_(nullptr)
+    , event_ordering_()
     , read_timeout_(pset.get<size_t>("read_timeout_us", static_cast<size_t>(pset.get<double>("waiting_time", 600.0) * 1000000)))
     , resume_after_timeout_(pset.get<bool>("resume_after_timeout", true))
 {
@@ -158,19 +157,14 @@ ArtdaqSharedMemoryService::~ArtdaqSharedMemoryService()
 	artdaq::Globals::CleanUpGlobals();
 }
 
-std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> ArtdaqSharedMemoryService::ReceiveEvent(bool broadcast)
+std::shared_ptr<ArtdaqEvent> ArtdaqSharedMemoryService::ReadEventFromSharedMemory(bool broadcast)
 {
-	TLOG(TLVL_DEBUG + 33) << "ReceiveEvent BEGIN";
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> recvd_fragments;
+	TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory BEGIN";
+	std::shared_ptr<ArtdaqEvent> output_event;
 
-	if (printed_exit_message_)
+	while (output_event == nullptr)
 	{
-		return recvd_fragments;
-	}
-
-	while (recvd_fragments.empty())
-	{
-		TLOG(TLVL_DEBUG + 33) << "ReceiveEvent: Waiting for available buffer";
+		TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory: Waiting for available buffer";
 		bool got_event = false;
 		auto start_time = std::chrono::steady_clock::now();
 		auto read_timeout_to_use = read_timeout_ > 100000 ? 100000 : read_timeout_;
@@ -181,13 +175,16 @@ std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>>
 			if (!got_event && (!resume_after_timeout_ || broadcast))  // Only try broadcasts once!
 			{
 				TLOG(TLVL_ERROR) << "Timeout occurred! No data received after " << read_timeout_to_use << " us. Returning empty Fragment list!";
-				return recvd_fragments;
+				last_read_timeout_ = true;
+				return nullptr;
 			}
 			if (!got_event && artdaq::TimeUtils::GetElapsedTimeMicroseconds(start_time) > read_timeout_)
 			{
 				TLOG(TLVL_WARNING) << "Timeout occurred! No data received after " << artdaq::TimeUtils::GetElapsedTimeMicroseconds(start_time) << " us. Retrying.";
+				last_read_timeout_ = true;
 			}
 		}
+
 		if (incoming_events_->IsEndOfData())
 		{
 			if (!printed_exit_message_)
@@ -195,56 +192,118 @@ std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>>
 				TLOG(TLVL_INFO) << "End of Data signal received, exiting";
 				printed_exit_message_ = true;
 			}
-			return recvd_fragments;
+			return nullptr;
 		}
 
-		TLOG(TLVL_DEBUG + 33) << "ReceiveEvent: Reading buffer header";
+		TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory: Reading buffer header";
+		last_read_timeout_ = false;
+		output_event = std::make_shared<ArtdaqEvent>();
 		auto errflag = false;
 		auto hdrPtr = incoming_events_->ReadHeader(errflag);
 		if (errflag || hdrPtr == nullptr)
 		{  // Buffer was changed out from under reader!
 			incoming_events_->ReleaseBuffer();
 			continue;  // retry
-			           // return recvd_fragments;
 		}
-		evtHeader_ = std::make_shared<artdaq::detail::RawEventHeader>(*hdrPtr);
-		TLOG(TLVL_DEBUG + 33) << "ReceiveEvent: Getting Fragment types";
+		output_event->header = std::make_shared<artdaq::detail::RawEventHeader>(*hdrPtr);
+		TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory: Getting Fragment types";
 		auto fragmentTypes = incoming_events_->GetFragmentTypes(errflag);
 		if (errflag)
 		{  // Buffer was changed out from under reader!
 			incoming_events_->ReleaseBuffer();
 			continue;  // retry
-			           // return recvd_fragments;
 		}
 		if (fragmentTypes.empty())
 		{
 			TLOG(TLVL_ERROR) << "Event has no Fragments! Aborting!";
 			incoming_events_->ReleaseBuffer();
-			return recvd_fragments;
+			return nullptr;
 		}
 
 		for (auto const& type : fragmentTypes)
 		{
-			TLOG(TLVL_DEBUG + 33) << "ReceiveEvent: Getting all Fragments of type " << static_cast<int>(type);
-			recvd_fragments[type] = incoming_events_->GetFragmentsByType(errflag, type);
-			if (!recvd_fragments[type])
+			TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory: Getting all Fragments of type " << static_cast<int>(type);
+			output_event->fragments[type] = incoming_events_->GetFragmentsByType(errflag, type);
+			if (!output_event->fragments[type])
 			{
 				TLOG(TLVL_WARNING) << "Error retrieving Fragments from shared memory! (Most likely due to a buffer overwrite) Retrying...";
 				incoming_events_->ReleaseBuffer();
-				recvd_fragments.clear();
+				output_event->fragments.clear();
 				continue;
 			}
-			/* Events coming out of the EventStore are not sorted but need to be
-	   sorted by sequence ID before they can be passed to art.
-	*/
-			std::sort(recvd_fragments[type]->begin(), recvd_fragments[type]->end(), artdaq::fragmentSequenceIDCompare);
+			// Events coming out of the EventStore are not sorted but need to be sorted by sequence ID before they can be passed to art.
+			std::sort(output_event->fragments[type]->begin(), output_event->fragments[type]->end(), artdaq::fragmentSequenceIDCompare);
 		}
-		TLOG(TLVL_DEBUG + 33) << "ReceiveEvent: Releasing buffer";
+		TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory: Releasing buffer";
 		incoming_events_->ReleaseBuffer();
 	}
 
+	TLOG(TLVL_DEBUG + 33) << "ReadEventFromSharedMemory END";
+	return output_event;
+}
+
+std::shared_ptr<ArtdaqEvent> ArtdaqSharedMemoryService::ReceiveEvent(bool broadcast)
+{
+	TLOG(TLVL_DEBUG + 33) << "ReceiveEvent BEGIN";
+	std::shared_ptr<ArtdaqEvent> output_event;
+
+	while (output_event == nullptr)
+	{
+		// If we experienced a timeout, drain any held Start/End Run/SubRun events
+		if (last_read_timeout_)
+		{
+			if (event_ordering_.size() > 0)
+			{
+				output_event = event_ordering_.front();
+				event_ordering_.pop_front();
+				break; // while(output_event == nullptr)
+			}
+		}
+
+		bool eventInEventOrder = false;
+		for (auto it = event_ordering_.begin(); it != event_ordering_.end(); ++it)
+		{
+			auto type = (*it)->FirstFragmentType();
+
+            // We will automatically start draining if we have an Init, EndOfData, or Event message
+			if (type == artdaq::Fragment::StartOfRunFragmentType || type == artdaq::Fragment::StartOfSubrunFragmentType 
+                || type == artdaq::Fragment::EndOfSubrunFragmentType || type == artdaq::Fragment::EndOfRunFragmentType
+                || type == artdaq::Fragment::RunDataFragmentType || type == artdaq::Fragment::SubrunDataFragmentType)
+			{
+				continue; // for (auto it = event_ordering_.begin(); it != event_ordering_.end(); ++it)
+			}
+			eventInEventOrder = true;
+			break; // for (auto it = event_ordering_.begin(); it != event_ordering_.end(); ++it)
+		}
+		if (eventInEventOrder)
+		{
+			output_event = event_ordering_.front();
+			event_ordering_.pop_front();
+			break; // while(output_event == nullptr)
+        }
+
+		auto next_event = ReadEventFromSharedMemory(broadcast);
+		if (next_event == nullptr)
+		{
+			if (event_ordering_.size() > 0)
+			{
+				output_event = event_ordering_.front();
+				event_ordering_.pop_front();
+			}
+			else
+			{
+                // Will return nullptr
+				break; // while(output_event == nullptr)
+			}
+		}
+		else
+		{
+			event_ordering_.push_back(next_event);
+			event_ordering_.sort();
+		}
+	}
 	TLOG(TLVL_DEBUG + 33) << "ReceiveEvent END";
-	return recvd_fragments;
+	return output_event;
 }
 
 DEFINE_ART_SERVICE_INTERFACE_IMPL(ArtdaqSharedMemoryService, ArtdaqSharedMemoryServiceInterface)

--- a/artdaq/ArtModules/detail/ListenTransferWrapper.cc
+++ b/artdaq/ArtModules/detail/ListenTransferWrapper.cc
@@ -213,10 +213,10 @@ artdaq::FragmentPtrs artdaq::ListenTransferWrapper::receiveMessage()
 	return fragmentPtrs;
 }
 
-std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>>
+std::shared_ptr<ArtdaqEvent>
 artdaq::ListenTransferWrapper::receiveMessages()
 {
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> output;
+	auto output = std::make_shared<ArtdaqEvent>();
 
 	auto ptrs = receiveMessage();
 	for (auto& ptr : ptrs)
@@ -225,12 +225,12 @@ artdaq::ListenTransferWrapper::receiveMessages()
 		auto fragPtr = ptr.release();
 		ptr.reset(nullptr);
 
-		if (output.count(fragType) == 0u)
+		if (output->fragments.count(fragType) == 0u)
 		{
-			output[fragType] = std::make_unique<artdaq::Fragments>();
+			output->fragments[fragType] = std::make_unique<artdaq::Fragments>();
 		}
 
-		output[fragType]->emplace_back(std::move(*fragPtr));
+		output->fragments[fragType]->emplace_back(std::move(*fragPtr));
 	}
 
 	return output;

--- a/artdaq/ArtModules/detail/ListenTransferWrapper.hh
+++ b/artdaq/ArtModules/detail/ListenTransferWrapper.hh
@@ -7,6 +7,7 @@
 
 #include "artdaq-core/Data/RawEvent.hh"
 #include "artdaq/TransferPlugins/TransferInterface.hh"
+#include  "artdaq/ArtModules/ArtdaqEvent.hh"
 
 namespace fhicl {
 class ParameterSet;
@@ -65,7 +66,7 @@ public:
 	 * \brief Receive all messsages for an event from ArtdaqSharedMemoryService
 	 * \return A map of Fragment::type_t to a unique_ptr to Fragments containing all Fragments in an event
 	 */
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> receiveMessages();
+	std::shared_ptr<ArtdaqEvent> receiveMessages();
 
 	/**
 	 * \brief Receive the Init message from the TransferInterface, and send it to art
@@ -75,12 +76,6 @@ public:
 	{
 		return receiveMessage();
 	}
-
-	/**
-	 * \brief Get a pointer to the last received RawEventHeader
-	 * \return a shared_ptr to the last received RawEventHeader
-	 */
-	std::shared_ptr<artdaq::detail::RawEventHeader> getEventHeader() { return nullptr; }
 
 private:
 	ListenTransferWrapper(ListenTransferWrapper const&) = delete;

--- a/artdaq/ArtModules/detail/ShmemWrapper.cc
+++ b/artdaq/ArtModules/detail/ShmemWrapper.cc
@@ -14,12 +14,12 @@ art::ShmemWrapper::ShmemWrapper(fhicl::ParameterSet const& ps)
 	art::ServiceHandle<ArtdaqSharedMemoryServiceInterface> shm;
 }
 
-std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> art::ShmemWrapper::receiveMessages()
+std::shared_ptr<ArtdaqEvent> art::ShmemWrapper::receiveMessages()
 {
 	TLOG(TLVL_DEBUG + 34) << "Receiving Fragment from NetMonTransportService";
 	TLOG(TLVL_DEBUG + 33) << "receiveMessage BEGIN";
 	art::ServiceHandle<ArtdaqSharedMemoryServiceInterface> shm;
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> output;
+	std::shared_ptr<ArtdaqEvent> output;
 
 	// Do not process data until Init Fragment received!
 	auto start = std::chrono::steady_clock::now();
@@ -34,13 +34,12 @@ std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>>
 
 	output = shm->ReceiveEvent(false);
 
-	if (output.empty())
+	if (output == nullptr)
 	{
 		TLOG(TLVL_DEBUG + 32) << "Did not receive event after timeout, returning from receiveMessage ";
 		return output;
 	}
 
-	hdr_ptr_ = shm->GetEventHeader();
 	TLOG(TLVL_DEBUG + 33) << "receiveMessage END";
 
 	TLOG(TLVL_DEBUG + 34) << "Done Receiving Fragments from Shared Memory";
@@ -54,26 +53,30 @@ artdaq::FragmentPtrs art::ShmemWrapper::receiveInitMessage()
 	TLOG(TLVL_DEBUG + 33) << "receiveInitMessage BEGIN";
 	art::ServiceHandle<ArtdaqSharedMemoryServiceInterface> shm;
 	auto start = std::chrono::steady_clock::now();
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> eventMap;
-	while (eventMap.empty())
+	std::shared_ptr<ArtdaqEvent> eventMap;
+	while (eventMap == nullptr)
 	{
 		eventMap = shm->ReceiveEvent(true);
 
-		if (eventMap.count(artdaq::Fragment::type_t(artdaq::Fragment::EndOfDataFragmentType)) != 0u)
+        if (eventMap != nullptr)
 		{
-			TLOG(TLVL_DEBUG + 32) << "Received shutdown message, returning";
-			artdaq::FragmentPtrs output;
-			for (auto& frag : *eventMap[artdaq::Fragment::EndOfDataFragmentType])
+			auto type = eventMap->FirstFragmentType();
+			if (type == artdaq::Fragment::EndOfDataFragmentType)
 			{
-				output.emplace_back(new artdaq::Fragment(std::move(frag)));
+				TLOG(TLVL_DEBUG + 32) << "Received shutdown message, returning";
+				artdaq::FragmentPtrs output;
+				for (auto& frag : *eventMap->fragments[artdaq::Fragment::EndOfDataFragmentType])
+				{
+					output.emplace_back(new artdaq::Fragment(std::move(frag)));
+				}
+				return output;
 			}
-			return output;
-		}
-		if ((eventMap.count(artdaq::Fragment::type_t(artdaq::Fragment::InitFragmentType)) == 0u) && !eventMap.empty())
-		{
-			TLOG(TLVL_WARNING) << "Did NOT receive Init Fragment as first broadcast! Type="
-			                   << artdaq::detail::RawFragmentHeader::SystemTypeToString(eventMap.begin()->first);
-			eventMap.clear();
+			if (type != artdaq::Fragment::InitFragmentType)
+			{
+				TLOG(TLVL_WARNING) << "Did NOT receive Init Fragment as first broadcast! Type="
+				                   << artdaq::detail::RawFragmentHeader::SystemTypeToString(type);
+				eventMap = nullptr;
+			}
 		}
 		else if (artdaq::TimeUtils::GetElapsedTime(start) > init_timeout_s_)
 		{
@@ -90,7 +93,7 @@ artdaq::FragmentPtrs art::ShmemWrapper::receiveInitMessage()
 
 	TLOG(TLVL_DEBUG + 33) << "receiveInitMessage: Returning top Fragment";
 	artdaq::FragmentPtrs output;
-	for (auto& frag : *eventMap[artdaq::Fragment::InitFragmentType])
+	for (auto& frag : *eventMap->fragments[artdaq::Fragment::InitFragmentType])
 	{
 		output.emplace_back(new artdaq::Fragment(std::move(frag)));
 	}

--- a/artdaq/ArtModules/detail/ShmemWrapper.hh
+++ b/artdaq/ArtModules/detail/ShmemWrapper.hh
@@ -7,6 +7,7 @@
 #include "fhiclcpp/ParameterSet.h"
 
 #include "artdaq-core/Data/RawEvent.hh"
+#include "artdaq/ArtModules/ArtdaqEvent.hh"
 
 #include <memory>
 #include <string>
@@ -40,19 +41,13 @@ public:
 	 * \brief Receive all messsages for an event from ArtdaqSharedMemoryService
 	 * \return A map of Fragment::type_t to a unique_ptr to Fragments containing all Fragments in an event
 	 */
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> receiveMessages();
+	std::shared_ptr<ArtdaqEvent> receiveMessages();
 
 	/**
 	 * \brief Receive an init message from the ArtdaqSharedMemoryService
 	 * \return A list of unique_ptrs to InitFragments
 	 */
 	artdaq::FragmentPtrs receiveInitMessage();
-
-	/**
-	 * \brief Get a pointer to the last received RawEventHeader
-	 * \return a shared_ptr to the last received RawEventHeader
-	 */
-	std::shared_ptr<artdaq::detail::RawEventHeader> getEventHeader() { return hdr_ptr_; }
 
 private:
 	ShmemWrapper(ShmemWrapper const&) = delete;
@@ -63,7 +58,6 @@ private:
 	fhicl::ParameterSet data_pset_;
 	bool init_received_;
 	double init_timeout_s_;
-	std::shared_ptr<artdaq::detail::RawEventHeader> hdr_ptr_;
 };
 }  // namespace art
 

--- a/artdaq/ArtModules/detail/TransferWrapper.cc
+++ b/artdaq/ArtModules/detail/TransferWrapper.cc
@@ -111,7 +111,6 @@ artdaq::FragmentPtrs artdaq::TransferWrapper::receiveMessage()
 			if (gSignalStatus != 0)
 			{
 				TLOG(TLVL_INFO) << "Ctrl-C appears to have been hit";
-				unregisterMonitor();
 				return fragmentPtrs;
 			}
 			if (!monitorRegistered_)
@@ -156,12 +155,6 @@ artdaq::FragmentPtrs artdaq::TransferWrapper::receiveMessage()
 				if (result == artdaq::TransferInterface::DATA_END)
 				{
 					TLOG(TLVL_ERROR) << "Transfer Plugin disconnected or other unrecoverable error. Shutting down.";
-					if (multi_run_mode_)
-					{
-						unregisterMonitor();
-						initialized = false;
-						continue;
-					}
 					return fragmentPtrs;
 				}
 				else
@@ -190,17 +183,6 @@ artdaq::FragmentPtrs artdaq::TransferWrapper::receiveMessage()
 
 		if (fragmentPtr->type() == artdaq::Fragment::EndOfDataFragmentType)
 		{
-			// if (monitorRegistered_)
-			//{
-			//	unregisterMonitor();
-			// }
-			if (multi_run_mode_)
-			{
-				unregisterMonitor();
-				initialized = false;
-				continue;
-			}
-
 			return fragmentPtrs;
 		}
 
@@ -222,9 +204,9 @@ artdaq::FragmentPtrs artdaq::TransferWrapper::receiveMessage()
 	return fragmentPtrs;
 }
 
-std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> artdaq::TransferWrapper::receiveMessages()
+std::shared_ptr<ArtdaqEvent> artdaq::TransferWrapper::receiveMessages()
 {
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> output;
+	std::shared_ptr<ArtdaqEvent> output = std::make_shared<ArtdaqEvent>();
 
 	auto ptrs = receiveMessage();
 	for (auto& ptr : ptrs)
@@ -233,12 +215,12 @@ std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>>
 		auto fragPtr = ptr.release();
 		ptr.reset(nullptr);
 
-		if (output.count(fragType) == 0u)
+		if (output->fragments.count(fragType) == 0u)
 		{
-			output[fragType] = std::make_unique<artdaq::Fragments>();
+			output->fragments[fragType] = std::make_unique<artdaq::Fragments>();
 		}
 
-		output[fragType]->emplace_back(std::move(*fragPtr));
+		output->fragments[fragType]->emplace_back(std::move(*fragPtr));
 	}
 
 	return output;
@@ -326,7 +308,7 @@ void artdaq::TransferWrapper::registerMonitor()
 
 	while (retry > 0)
 	{
-		label_ = dispatcherConfig.get<std::string>("unique_label");
+		label_ = dispatcherConfig.get<std::string>("unique_label") + "_" + std::to_string(time(0));
 		TLOG(TLVL_INFO) << "Attempting to register this monitor (\"" << label_
 		                << "\") with the dispatcher aggregator";
 

--- a/artdaq/ArtModules/detail/TransferWrapper.hh
+++ b/artdaq/ArtModules/detail/TransferWrapper.hh
@@ -4,6 +4,7 @@
 #include "artdaq-core/Data/RawEvent.hh"
 #include "artdaq/ExternalComms/CommanderInterface.hh"
 #include "artdaq/TransferPlugins/TransferInterface.hh"
+#include "artdaq/ArtModules/ArtdaqEvent.hh"
 
 namespace fhicl {
 class ParameterSet;
@@ -69,7 +70,7 @@ public:
 	 * \brief Receive all messsages for an event from ArtdaqSharedMemoryService
 	 * \return A map of Fragment::type_t to a unique_ptr to Fragments containing all Fragments in an event
 	 */
-	std::unordered_map<artdaq::Fragment::type_t, std::unique_ptr<artdaq::Fragments>> receiveMessages();
+	std::shared_ptr<ArtdaqEvent> receiveMessages();
 
 	/**
 	 * \brief Receive the Init message from the TransferInterface, and send it to art
@@ -79,12 +80,6 @@ public:
 	{
 		return receiveMessage();
 	}
-
-	/**
-	 * \brief Get a pointer to the last received RawEventHeader
-	 * \return a shared_ptr to the last received RawEventHeader
-	 */
-	std::shared_ptr<artdaq::detail::RawEventHeader> getEventHeader() { return nullptr; }
 
 private:
 	TransferWrapper(TransferWrapper const&) = delete;

--- a/artdaq/DAQrate/SharedMemoryEventManager.hh
+++ b/artdaq/DAQrate/SharedMemoryEventManager.hh
@@ -370,7 +370,7 @@ public:
 	 * @param frag Fragment to broadcast
 	 * @param max_delay Length of time to wait for more Fragments to broadcast
 	 */
-	void BroadcastFragment(FragmentPtr& frag, std::chrono::microseconds max_delay = std::chrono::microseconds(100000));
+	void BroadcastFragment(FragmentPtr& frag, std::chrono::microseconds max_delay = std::chrono::microseconds(1000));
 
 	/**
 	 * \brief Gets the shared memory key of the broadcast SharedMemoryManager


### PR DESCRIPTION
Allow holding run/subrun events until we are sure that they are in the correct sequence.