### PR TITLE
Add capture_art_stdout and capture_art_stderr FHiCL parameters

### DIFF
--- a/artdaq/DAQrate/SharedMemoryEventManager.cc
+++ b/artdaq/DAQrate/SharedMemoryEventManager.cc
@@ -95,6 +95,8 @@ artdaq::SharedMemoryEventManager::SharedMemoryEventManager(const fhicl::Paramete
     , art_process_index_offset_(pset.get<size_t>("art_index_offset", 0))
     , minimum_art_lifetime_s_(pset.get<double>("minimum_art_lifetime_s", 2.0))
     , art_event_processing_time_us_(pset.get<size_t>("expected_art_event_processing_time_us", 1000000))
+    , capture_art_stdout_(pset.get<bool>("capture_art_stdout", true))
+    , capture_art_stderr_(pset.get<bool>("capture_art_stderr", true))
     , requests_(nullptr)
     , tokens_(nullptr)
     , data_pset_(pset)
@@ -599,7 +601,7 @@ void artdaq::SharedMemoryEventManager::RunArt(size_t process_index, const std::s
 					if (fds[0].revents & POLLIN)
 					{
 						ssize_t count = read(stdoutpipefd[0], buf, sizeof(buf) - 1);
-						if (count > 0)
+						if (count > 0 && capture_art_stdout_)
 						{
 							TLOG(TLVL_INFO, art_tname) << std::string(buf, count);
 						}
@@ -607,7 +609,7 @@ void artdaq::SharedMemoryEventManager::RunArt(size_t process_index, const std::s
 					if (fds[1].revents & POLLIN)
 					{
 						ssize_t count = read(stderrpipefd[0], buf, sizeof(buf) - 1);
-						if (count > 0)
+						if (count > 0 && capture_art_stderr_)
 						{
 							TLOG(TLVL_ERROR, art_tname) << std::string(buf, count);
 						}

--- a/artdaq/DAQrate/SharedMemoryEventManager.cc
+++ b/artdaq/DAQrate/SharedMemoryEventManager.cc
@@ -586,7 +586,7 @@ void artdaq::SharedMemoryEventManager::RunArt(size_t process_index, const std::s
 				close(stdoutpipefd[1]);  // Close write end of stdout pipe
 				close(stderrpipefd[1]);  // Close write end of stderr pipe
 
-				std::string art_tname = "art[" + std::to_string(pid) + "]";
+				std::string art_tname = app_name + "_art_stdout";
 				char buf[PIPE_BUF];
 				struct pollfd fds[2];
 				fds[0].fd = stdoutpipefd[0];

--- a/artdaq/DAQrate/SharedMemoryEventManager.hh
+++ b/artdaq/DAQrate/SharedMemoryEventManager.hh
@@ -186,6 +186,10 @@ public:
 		fhicl::Atom<size_t> broadcast_buffer_size{fhicl::Name{"broadcast_buffer_size"}, fhicl::Comment{"Size of the buffers in the broadcast shared memory segment"}, 0x100000};
 		/// "use_art" (Default: true): Whether to start and manage art threads (Sets art_analyzer count to 0 and overwrite_mode to true when false)
 		fhicl::Atom<bool> use_art{fhicl::Name{"use_art"}, fhicl::Comment{"Whether to start and manage art threads (Sets art_analyzer count to 0 and overwrite_mode to true when false)"}, true};
+		/// "capture_art_stdout" (Default: true): Whether to capture the stdout and relay it to TLOG_INFO
+		fhicl::Atom<bool> capture_art_stdout{fhicl::Name{"capture_art_stdout"}, fhicl::Comment{"Whether to capture the stdout and relay it to TLOG_INFO"}, true};
+		/// "capture_art_stderr" (Default: true): Whether to capture the stderr and relay it to TLOG_ERROR
+		fhicl::Atom<bool> capture_art_stderr{fhicl::Name{"capture_art_stderr"}, fhicl::Comment{"Whether to capture the stderr and relay it to TLOG_ERROR"}, true};
 		/// "manual_art" (Default: false): Prints the startup command line for the art process so that the user may (for example) run it in GDB or valgrind
 		fhicl::Atom<bool> manual_art{fhicl::Name{"manual_art"}, fhicl::Comment{"Prints the startup command line for the art process so that the user may (for example) run it in GDB or valgrind"}, false};
 		/// Configuration of the RequestSender. See artdaq::RequestSender::Config
@@ -512,6 +516,8 @@ private:
 	size_t art_process_index_offset_;
 	double minimum_art_lifetime_s_;
 	size_t art_event_processing_time_us_;
+	bool capture_art_stdout_;
+	bool capture_art_stderr_;
 
 	std::unique_ptr<RequestSender> requests_;
 	std::unique_ptr<TokenSender> tokens_;


### PR DESCRIPTION
Allows users to silence the output from the art process if it is being too verbose/recorded elsewhere.