### PR TITLE
Add reset_event_number_for_subruns feature

### DIFF
--- a/artdaq/DAQrate/SharedMemoryEventManager.cc
+++ b/artdaq/DAQrate/SharedMemoryEventManager.cc
@@ -1202,13 +1202,13 @@ artdaq::SharedMemoryEventManager::subrun_id_t artdaq::SharedMemoryEventManager::
 
 artdaq::SharedMemoryEventManager::event_id_t artdaq::SharedMemoryEventManager::GetEventIDForFragment(Fragment::sequence_id_t seqID, Fragment::timestamp_t timestamp)
 {
-    event_id_t event = 1;
-    if (init_fragment_count_ > 0)
-    {
+	event_id_t event = 1;
+	if (init_fragment_count_ > 0)
+	{
 		TLOG(TLVL_GETEVENTID) << "init_fragment_count > 0 (processing art events): Decoding event ID from sequenceID " << seqID;
-        event = seqID & 0xFFFFFFFF;
-    }
-    else
+		event = seqID & 0xFFFFFFFF;
+	}
+	else
 	{
 		sequence_id_t subrun_start = 0;
 		if (reset_event_number_for_subruns_)
@@ -1224,10 +1224,10 @@ artdaq::SharedMemoryEventManager::event_id_t artdaq::SharedMemoryEventManager::G
 			}
 		}
 
-        event = use_sequence_id_for_event_number_ ? (seqID - subrun_start) : (timestamp - subrun_start);
-    }
-    TLOG(TLVL_GETEVENTID) << "GetEventIDForFragment returning event ID " << event << " for sequence ID " << seqID;
-    return event;
+		event = use_sequence_id_for_event_number_ ? (seqID - subrun_start) : (timestamp - subrun_start);
+	}
+	TLOG(TLVL_GETEVENTID) << "GetEventIDForFragment returning event ID " << event << " for sequence ID " << seqID;
+	return event;
 }
 
 int artdaq::SharedMemoryEventManager::getBufferForSequenceID_(Fragment::sequence_id_t seqID, bool create_new, Fragment::timestamp_t timestamp)

--- a/artdaq/DAQrate/SharedMemoryEventManager.cc
+++ b/artdaq/DAQrate/SharedMemoryEventManager.cc
@@ -33,7 +33,7 @@
 #define TLVL_GETBUFFER              48
 #define TLVL_GETFRAGMENTCOUNT       49
 #define TLVL_GETSUBRUN              50
-#define TLVL_GETSUBRUN_2            51
+#define TLVL_GETEVENTID             51
 #define TLVL_PARSEARTCOMMANDLINE    52
 #define TLVL_RECONFIGUREART         53
 #define TLVL_RUNART                 54
@@ -71,6 +71,7 @@ artdaq::SharedMemoryEventManager::SharedMemoryEventManager(const fhicl::Paramete
     , max_event_list_length_(pset.get<size_t>("max_event_list_length", 100))
     , update_run_ids_(pset.get<bool>("update_run_ids_on_new_fragment", true))
     , use_sequence_id_for_event_number_(pset.get<bool>("use_sequence_id_for_event_number", true))
+    , reset_event_number_for_subruns_(pset.get<bool>("reset_event_number_for_subruns", false))
     , overwrite_mode_(!pset.get<bool>("use_art", true) || pset.get<bool>("overwrite_mode", false) || pset.get<bool>("broadcast_mode", false))
     , init_fragment_count_(pset.get<size_t>("init_fragment_count", pset.get<bool>("send_init_fragments", true) ? 1 : 0))
     , running_(false)
@@ -207,6 +208,7 @@ bool artdaq::SharedMemoryEventManager::AddFragment(detail::RawFragmentHeader fra
 		hdr->subrun_id = subrun_id_;
 	}
 	hdr->subrun_id = GetSubrunForSequenceID(frag.sequence_id);
+	hdr->event_id = GetEventIDForFragment(frag.sequence_id, frag.timestamp);
 
 	TLOG(TLVL_ADDFRAGMENT) << "AddFragment before Write calls";
 	Write(buffer, dataPtr, frag.word_count * sizeof(RawDataType));
@@ -388,6 +390,7 @@ void artdaq::SharedMemoryEventManager::DoneWritingFragment(detail::RawFragmentHe
 			hdr->subrun_id = subrun_id_;
 		}
 		hdr->subrun_id = GetSubrunForSequenceID(frag.sequence_id);
+		hdr->event_id = GetEventIDForFragment(frag.sequence_id, frag.timestamp);
 
 		TLOG(TLVL_DONEWRITINGFRAGMENT) << "DoneWritingFragment: Updating buffer touch time";
 		TouchBuffer(buffer);
@@ -1175,19 +1178,19 @@ artdaq::SharedMemoryEventManager::subrun_id_t artdaq::SharedMemoryEventManager::
 	subrun_id_t subrun = 1;
 	if (init_fragment_count_ > 0)
 	{
-		TLOG(TLVL_GETSUBRUN_2) << "init_fragment_count > 0 (processing art events): Decoding subrun from sequenceID " << seqID;
+		TLOG(TLVL_GETSUBRUN) << "init_fragment_count > 0 (processing art events): Decoding subrun from sequenceID " << seqID;
 		subrun = seqID >> 32;
 	}
 	else
 	{
 		std::unique_lock<std::mutex> lk(subrun_event_map_mutex_);
 
-		TLOG(TLVL_GETSUBRUN_2) << "GetSubrunForSequenceID BEGIN map size = " << subrun_event_map_.size();
+		TLOG(TLVL_GETSUBRUN) << "GetSubrunForSequenceID BEGIN map size = " << subrun_event_map_.size();
 		auto it = subrun_event_map_.begin();
 
 		while (it->first <= seqID && it != subrun_event_map_.end())
 		{
-			TLOG(TLVL_GETSUBRUN_2) << "Map has sequence ID " << it->first << ", subrun " << it->second << " (looking for <= " << seqID << ")";
+			TLOG(TLVL_GETSUBRUN) << "Map has sequence ID " << it->first << ", subrun " << it->second << " (looking for <= " << seqID << ")";
 			subrun = it->second;
 			++it;
 		}
@@ -1195,6 +1198,36 @@ artdaq::SharedMemoryEventManager::subrun_id_t artdaq::SharedMemoryEventManager::
 
 	TLOG(TLVL_GETSUBRUN) << "GetSubrunForSequenceID returning subrun " << subrun << " for sequence ID " << seqID;
 	return subrun;
+}
+
+artdaq::SharedMemoryEventManager::event_id_t artdaq::SharedMemoryEventManager::GetEventIDForFragment(Fragment::sequence_id_t seqID, Fragment::timestamp_t timestamp)
+{
+    event_id_t event = 1;
+    if (init_fragment_count_ > 0)
+    {
+		TLOG(TLVL_GETEVENTID) << "init_fragment_count > 0 (processing art events): Decoding event ID from sequenceID " << seqID;
+        event = seqID & 0xFFFFFFFF;
+    }
+    else
+	{
+		sequence_id_t subrun_start = 0;
+		if (reset_event_number_for_subruns_)
+		{
+			std::unique_lock<std::mutex> lk(subrun_event_map_mutex_);
+			TLOG(TLVL_GETEVENTID) << "GetEventIDForFragment BEGIN map size = " << subrun_event_map_.size();
+			auto it = subrun_event_map_.begin();
+			while (it->first < seqID && it != subrun_event_map_.end())
+			{
+				TLOG(TLVL_GETEVENTID) << "Map has sequence ID " << it->first << ", event " << it->second << " (looking for <= " << seqID << ")";
+				subrun_start = it->first;
+				++it;
+			}
+		}
+
+        event = use_sequence_id_for_event_number_ ? (seqID - subrun_start) : (timestamp - subrun_start);
+    }
+    TLOG(TLVL_GETEVENTID) << "GetEventIDForFragment returning event ID " << event << " for sequence ID " << seqID;
+    return event;
 }
 
 int artdaq::SharedMemoryEventManager::getBufferForSequenceID_(Fragment::sequence_id_t seqID, bool create_new, Fragment::timestamp_t timestamp)
@@ -1255,7 +1288,7 @@ int artdaq::SharedMemoryEventManager::getBufferForSequenceID_(Fragment::sequence
 	hdr->is_complete = false;
 	hdr->run_id = run_id_;
 	hdr->subrun_id = GetSubrunForSequenceID(seqID);
-	hdr->event_id = use_sequence_id_for_event_number_ ? static_cast<uint32_t>(seqID) : static_cast<uint32_t>(timestamp);
+	hdr->event_id = GetEventIDForFragment(seqID, timestamp);
 	hdr->sequence_id = seqID;
 	hdr->timestamp = timestamp;
 	buffer_writes_pending_[new_buffer] = 0;

--- a/artdaq/DAQrate/SharedMemoryEventManager.hh
+++ b/artdaq/DAQrate/SharedMemoryEventManager.hh
@@ -440,13 +440,13 @@ public:
 	 */
 	subrun_id_t GetSubrunForSequenceID(Fragment::sequence_id_t seqID);
 
-    /**
+	/**
 	 * \brief Get the event ID that the given Sequence ID and Timestamp would be assigned to
 	 * \param seqID Sequence ID to check
 	 * \param timestamp Timestamp to check
 	 * \return Event ID that the given sequence ID and/or timestamp will be associated with. Uses Sequence ID if use_sequence_id_for_event_number is true, Timestamp otherwise
-     */
-    event_id_t GetEventIDForFragment(Fragment::sequence_id_t seqID, Fragment::timestamp_t timestamp);
+	 */
+	event_id_t GetEventIDForFragment(Fragment::sequence_id_t seqID, Fragment::timestamp_t timestamp);
 
 	/**
 	 * \brief Get the current subrun number (Gets the last defined subrun)

--- a/artdaq/DAQrate/SharedMemoryEventManager.hh
+++ b/artdaq/DAQrate/SharedMemoryEventManager.hh
@@ -120,6 +120,7 @@ public:
 
 	typedef RawEvent::run_id_t run_id_t;                     ///< Copy RawEvent::run_id_t into local scope
 	typedef RawEvent::subrun_id_t subrun_id_t;               ///< Copy RawEvent::subrun_id_t into local scope
+	typedef RawEvent::event_id_t event_id_t;                 ///< Copy RawEvent::event_id_t into local scope
 	typedef Fragment::sequence_id_t sequence_id_t;           ///< Copy Fragment::sequence_id_t into local scope
 	typedef std::map<sequence_id_t, RawEvent_ptr> EventMap;  ///< An EventMap is a map of RawEvent_ptr objects, keyed by sequence ID
 
@@ -158,6 +159,8 @@ public:
 		fhicl::Atom<bool> update_run_ids_on_new_fragment{fhicl::Name{"update_run_ids_on_new_fragment"}, fhicl::Comment{"Whether the run and subrun ID of an event should be updated whenever a Fragment is added."}, true};
 		/// "use_sequence_id_for_event_number" (Default: true): Whether to use the artdaq Sequence ID (true) or the Timestamp (false) for art Event numbers
 		fhicl::Atom<bool> use_sequence_id_for_event_number{fhicl::Name{"use_sequence_id_for_event_number"}, fhicl::Comment{"Whether to use the artdaq Sequence ID (true) or the Timestamp (false) for art Event numbers"}, true};
+		/// "reset_event_number_for_subruns" (Default: false): Whether to start new subruns at Event ID 1 (true), or keep counting from the beginning of the run (false)
+		fhicl::Atom<bool> reset_event_number_for_subruns{fhicl::Name{"reset_event_number_for_subruns"}, fhicl::Comment{"Whether to start new subruns at Event ID 1 (true), or keep counting from the beginning of the run (false)"}, false};
 		/// "max_subrun_lookup_table_size" (Default: 100): The maximum number of entries to store in the sequence ID-SubRun ID lookup table
 		fhicl::Atom<size_t> max_subrun_lookup_table_size{fhicl::Name{"max_subrun_lookup_table_size"}, fhicl::Comment{"The maximum number of entries to store in the sequence ID-SubRun ID lookup table"}, 100};
 		/// "max_event_list_length" (Default: 100): The maximum number of entries to store in the released events list
@@ -437,6 +440,14 @@ public:
 	 */
 	subrun_id_t GetSubrunForSequenceID(Fragment::sequence_id_t seqID);
 
+    /**
+	 * \brief Get the event ID that the given Sequence ID and Timestamp would be assigned to
+	 * \param seqID Sequence ID to check
+	 * \param timestamp Timestamp to check
+	 * \return Event ID that the given sequence ID and/or timestamp will be associated with. Uses Sequence ID if use_sequence_id_for_event_number is true, Timestamp otherwise
+     */
+    event_id_t GetEventIDForFragment(Fragment::sequence_id_t seqID, Fragment::timestamp_t timestamp);
+
 	/**
 	 * \brief Get the current subrun number (Gets the last defined subrun)
 	 * \return Number of the subrun that corresponds to events with the maximum possible sequence ID.
@@ -480,6 +491,7 @@ private:
 
 	bool update_run_ids_;
 	bool use_sequence_id_for_event_number_;
+	bool reset_event_number_for_subruns_;
 	bool overwrite_mode_;
 	size_t init_fragment_count_;
 	std::atomic<bool> running_;


### PR DESCRIPTION
Add reset_event_number_for_subruns bool, which if set to true (default is false), will reset the Event number to 0 at the start of each subrun.

Needed by Mu2e, as they want to avoid 32-bit Event ID rollovers during a subrun.